### PR TITLE
Improve console reporter output

### DIFF
--- a/test/basic/expected_log.txt
+++ b/test/basic/expected_log.txt
@@ -1,117 +1,175 @@
-[ TEST ] 0 test_fail_assert_false_define
-[ FAIL ] 0 |  | test.c:64: assertion failed: '!(B > A)' - check error messages with preprocessor definitions
-[ TEST ] 1 test_fail_assert_false_literal
-[ FAIL ] 1 |  | test.c:49: assertion failed: '!(20 > 10)' - check error messages with literals
-[ TEST ] 2 test_fail_assert_false_no_message
-[ FAIL ] 2 |  | test.c:45: assertion failed: '!(20 > 10)' - 
-[ TEST ] 3 test_fail_assert_false_var
-[ FAIL ] 3 |  | test.c:57: assertion failed: '!(a != b)' - check error messages with variable names
-[ TEST ] 4 test_fail_assert_int_eq_define
-[ FAIL ] 4 |  | test.c:155: assertion failed: 'A == B'. Values: 5, 10. check error messages with preprocessor definitions
-[ TEST ] 5 test_fail_assert_int_eq_formatted_message
-[ FAIL ] 5 |  | test.c:135: assertion failed: 'a == b'. Values: 2, -3. sum: -1
-[ TEST ] 6 test_fail_assert_int_eq_literal
-[ FAIL ] 6 |  | test.c:140: assertion failed: '-20 == 10'. Values: -20, 10. check error messages with literals
-[ TEST ] 7 test_fail_assert_int_eq_var
-[ FAIL ] 7 |  | test.c:148: assertion failed: 'a == b'. Values: 2, -3. check error messages with variable names
-[ TEST ] 8 test_fail_assert_int_ne_define
-[ FAIL ] 8 |  | test.c:182: assertion failed: 'A != B'. Values: -500, -500. check error messages with preprocessor definitions
-[ TEST ] 9 test_fail_assert_int_ne_literal
-[ FAIL ] 9 |  | test.c:167: assertion failed: '-20 != -20'. Values: -20, -20. check error messages with literals
-[ TEST ] 10 test_fail_assert_int_ne_var
-[ FAIL ] 10 |  | test.c:175: assertion failed: 'a != b'. Values: 3, 3. check error messages with variable names
-[ TEST ] 11 test_fail_assert_mem_eq_first_byte
-[ FAIL ] 11 |  | test.c:307: assertion failed: buffers are not equal.first byte different - Values: aabbcc, ddbbcc
-[ TEST ] 12 test_fail_assert_mem_eq_last_byte
-[ FAIL ] 12 |  | test.c:315: assertion failed: buffers are not equal.last byte different - Values: aabbcc, aabbdd
-[ TEST ] 13 test_fail_assert_mem_eq_no_message
-[ FAIL ] 13 |  | test.c:299: assertion failed: buffers are not equal. - Values: aabbcc, ddbbcc
-[ TEST ] 14 test_fail_assert_mem_eq_truncated_buf
-[ FAIL ] 14 |  | test.c:329: assertion failed: buffers are not equal.big buffer, last byte different - Values: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e, 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e
-[ TEST ] 15 test_fail_assert_mem_ne
-[ FAIL ] 15 |  | test.c:357: assertion failed: buffers are not equal.same content, size: 3 - Values: aabbcc, aabbcc
-[ TEST ] 16 test_fail_assert_ptr_eq
-[ FAIL ] 16 |  | test.c:205: assertion failed: 'ptr == NULL'. Values: 0x80000001, (nil). comparing valid pointer to NULL
-[ TEST ] 17 test_fail_assert_ptr_ne
-[ FAIL ] 17 |  | test.c:227: assertion failed: 'ptr != ptr'. Values: 0x80000001, 0x80000001. comparing the same pointer
-[ TEST ] 18 test_fail_assert_str_eq_define
-[ FAIL ] 18 |  | test.c:252: assertion failed: 'strcmp(STRING1, STRING2) == 0'. Values: 'asdfghjkl', ''. check error messages with preprocessor definitions
-[ TEST ] 19 test_fail_assert_str_eq_literal
-[ FAIL ] 19 |  | test.c:237: assertion failed: 'strcmp("abcdef", "zyx") == 0'. Values: 'abcdef', 'zyx'. check error messages with literals
-[ TEST ] 20 test_fail_assert_str_eq_var
-[ FAIL ] 20 |  | test.c:245: assertion failed: 'strcmp(s1, s2) == 0'. Values: 'eee', 'qwertyuiop'. check error messages with variables
-[ TEST ] 21 test_fail_assert_str_ne_define
-[ FAIL ] 21 |  | test.c:280: assertion failed: 'strcmp(STRING1, STRING2) != 0'. Values: 'asdfghjkl', 'asdfghjkl'. check error messages with preprocessor definitions
-[ TEST ] 22 test_fail_assert_str_ne_literal
-[ FAIL ] 22 |  | test.c:265: assertion failed: 'strcmp("zxcvbnm", "zxcvbnm") != 0'. Values: 'zxcvbnm', 'zxcvbnm'. check error messages with literals
-[ TEST ] 23 test_fail_assert_str_ne_var
-[ FAIL ] 23 |  | test.c:273: assertion failed: 'strcmp(s1, s2) != 0'. Values: 'qwertyuiop', 'qwertyuiop'. check error messages with variables
-[ TEST ] 24 test_fail_assert_true_define
-[ FAIL ] 24 |  | test.c:35: assertion failed: 'A > B' - check error messages with preprocessor definitions
-[ TEST ] 25 test_fail_assert_true_formatted_message
-[ FAIL ] 25 |  | test.c:15: assertion failed: '0 > 1' - not that useful
-[ TEST ] 26 test_fail_assert_true_literal
-[ FAIL ] 26 |  | test.c:20: assertion failed: '0 > 1' - check error messages with literals
-[ TEST ] 27 test_fail_assert_true_var
-[ FAIL ] 27 |  | test.c:28: assertion failed: 'a == b' - check error messages with variable names
-[ TEST ] 28 test_fail_assert_uint_eq_define
-[ FAIL ] 28 |  | test.c:93: assertion failed: 'A == B'. Values: 5, 10. check error messages with preprocessor definitions
-[ TEST ] 29 test_fail_assert_uint_eq_literal
-[ FAIL ] 29 |  | test.c:78: assertion failed: '20 == 10'. Values: 20, 10. check error messages with literals
-[ TEST ] 30 test_fail_assert_uint_eq_no_message
-[ FAIL ] 30 |  | test.c:74: assertion failed: '20 == 10'. Values: 20, 10. 
-[ TEST ] 31 test_fail_assert_uint_eq_var
-[ FAIL ] 31 |  | test.c:86: assertion failed: 'a == b'. Values: 2, 3. check error messages with variable names
-[ TEST ] 32 test_fail_assert_uint_ne_define
-[ FAIL ] 32 |  | test.c:120: assertion failed: 'A != B'. Values: 500, 500. check error messages with preprocessor definitions
-[ TEST ] 33 test_fail_assert_uint_ne_literal
-[ FAIL ] 33 |  | test.c:105: assertion failed: '20 != 20'. Values: 20, 20. check error messages with literals
-[ TEST ] 34 test_fail_assert_uint_ne_var
-[ FAIL ] 34 |  | test.c:113: assertion failed: 'a != b'. Values: 3, 3. check error messages with variable names
-[ TEST ] 35 test_fail_in_setup
-[ FAIL ] 35 |  | test.c:360: assertion failed: '1 == 4' - this should fail
-[ TEST ] 36 test_fail_with_custom_func
-[ FAIL ] 36 |  | test.c:405: assertion failed: 'false' - 
-[ TEST ] 37 test_fail_with_free
-[ FAIL ] 37 |  | test.c:388: assertion failed: 'false' - 
-[ TEST ] 38 test_fail_with_null_handler
-[ FAIL ] 38 |  | test.c:412: assertion failed: 'false' - 
-[ TEST ] 39 test_pass_assert_false
-[ PASS ] 39 | 
-[ TEST ] 40 test_pass_assert_int_eq
-[ PASS ] 40 | 
-[ TEST ] 41 test_pass_assert_int_ne
-[ PASS ] 41 | 
-[ TEST ] 42 test_pass_assert_mem_eq
-[ PASS ] 42 | 
-[ TEST ] 43 test_pass_assert_mem_ne
-[ PASS ] 43 | 
-[ TEST ] 44 test_pass_assert_ptr_eq
-[ PASS ] 44 | 
-[ TEST ] 45 test_pass_assert_ptr_eq_null
-[ PASS ] 45 | 
-[ TEST ] 46 test_pass_assert_ptr_ne
-[ PASS ] 46 | 
-[ TEST ] 47 test_pass_assert_ptr_ne_null
-[ PASS ] 47 | 
-[ TEST ] 48 test_pass_assert_str_eq
-[ PASS ] 48 | 
-[ TEST ] 49 test_pass_assert_str_ne
-[ PASS ] 49 | 
-[ TEST ] 50 test_pass_assert_true
-[ PASS ] 50 | 
-[ TEST ] 51 test_pass_assert_uint_eq
-[ PASS ] 51 | 
-[ TEST ] 52 test_pass_assert_uint_ne
-[ PASS ] 52 | 
-[ TEST ] 53 test_pass_in_setup
-[ PASS ] 53 | 
-[ TEST ] 54 test_skip
-[ SKIP ] 54 |  |  testing SKIP
-[ TEST ] 55 test_skip_without_reason
-[ SKIP ] 55 |  |  
++------+
+| TEST | (0) test_fail_assert_false_define
+| FAIL | (0)  | test.c:64: assertion failed: '!(B > A)' - check error messages with preprocessor definitions
++------+
+| TEST | (1) test_fail_assert_false_literal
+| FAIL | (1)  | test.c:49: assertion failed: '!(20 > 10)' - check error messages with literals
++------+
+| TEST | (2) test_fail_assert_false_no_message
+| FAIL | (2)  | test.c:45: assertion failed: '!(20 > 10)' - 
++------+
+| TEST | (3) test_fail_assert_false_var
+| FAIL | (3)  | test.c:57: assertion failed: '!(a != b)' - check error messages with variable names
++------+
+| TEST | (4) test_fail_assert_int_eq_define
+| FAIL | (4)  | test.c:155: assertion failed: 'A == B'. Values: 5, 10. check error messages with preprocessor definitions
++------+
+| TEST | (5) test_fail_assert_int_eq_formatted_message
+| FAIL | (5)  | test.c:135: assertion failed: 'a == b'. Values: 2, -3. sum: -1
++------+
+| TEST | (6) test_fail_assert_int_eq_literal
+| FAIL | (6)  | test.c:140: assertion failed: '-20 == 10'. Values: -20, 10. check error messages with literals
++------+
+| TEST | (7) test_fail_assert_int_eq_var
+| FAIL | (7)  | test.c:148: assertion failed: 'a == b'. Values: 2, -3. check error messages with variable names
++------+
+| TEST | (8) test_fail_assert_int_ne_define
+| FAIL | (8)  | test.c:182: assertion failed: 'A != B'. Values: -500, -500. check error messages with preprocessor definitions
++------+
+| TEST | (9) test_fail_assert_int_ne_literal
+| FAIL | (9)  | test.c:167: assertion failed: '-20 != -20'. Values: -20, -20. check error messages with literals
++------+
+| TEST | (10) test_fail_assert_int_ne_var
+| FAIL | (10)  | test.c:175: assertion failed: 'a != b'. Values: 3, 3. check error messages with variable names
++------+
+| TEST | (11) test_fail_assert_mem_eq_first_byte
+| FAIL | (11)  | test.c:307: assertion failed: buffers are not equal.first byte different - Values: aabbcc, ddbbcc
++------+
+| TEST | (12) test_fail_assert_mem_eq_last_byte
+| FAIL | (12)  | test.c:315: assertion failed: buffers are not equal.last byte different - Values: aabbcc, aabbdd
++------+
+| TEST | (13) test_fail_assert_mem_eq_no_message
+| FAIL | (13)  | test.c:299: assertion failed: buffers are not equal. - Values: aabbcc, ddbbcc
++------+
+| TEST | (14) test_fail_assert_mem_eq_truncated_buf
+| FAIL | (14)  | test.c:329: assertion failed: buffers are not equal.big buffer, last byte different - Values: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e, 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e
++------+
+| TEST | (15) test_fail_assert_mem_ne
+| FAIL | (15)  | test.c:357: assertion failed: buffers are not equal.same content, size: 3 - Values: aabbcc, aabbcc
++------+
+| TEST | (16) test_fail_assert_ptr_eq
+| FAIL | (16)  | test.c:205: assertion failed: 'ptr == NULL'. Values: 0x80000001, (nil). comparing valid pointer to NULL
++------+
+| TEST | (17) test_fail_assert_ptr_ne
+| FAIL | (17)  | test.c:227: assertion failed: 'ptr != ptr'. Values: 0x80000001, 0x80000001. comparing the same pointer
++------+
+| TEST | (18) test_fail_assert_str_eq_define
+| FAIL | (18)  | test.c:252: assertion failed: 'strcmp(STRING1, STRING2) == 0'. Values: 'asdfghjkl', ''. check error messages with preprocessor definitions
++------+
+| TEST | (19) test_fail_assert_str_eq_literal
+| FAIL | (19)  | test.c:237: assertion failed: 'strcmp("abcdef", "zyx") == 0'. Values: 'abcdef', 'zyx'. check error messages with literals
++------+
+| TEST | (20) test_fail_assert_str_eq_var
+| FAIL | (20)  | test.c:245: assertion failed: 'strcmp(s1, s2) == 0'. Values: 'eee', 'qwertyuiop'. check error messages with variables
++------+
+| TEST | (21) test_fail_assert_str_ne_define
+| FAIL | (21)  | test.c:280: assertion failed: 'strcmp(STRING1, STRING2) != 0'. Values: 'asdfghjkl', 'asdfghjkl'. check error messages with preprocessor definitions
++------+
+| TEST | (22) test_fail_assert_str_ne_literal
+| FAIL | (22)  | test.c:265: assertion failed: 'strcmp("zxcvbnm", "zxcvbnm") != 0'. Values: 'zxcvbnm', 'zxcvbnm'. check error messages with literals
++------+
+| TEST | (23) test_fail_assert_str_ne_var
+| FAIL | (23)  | test.c:273: assertion failed: 'strcmp(s1, s2) != 0'. Values: 'qwertyuiop', 'qwertyuiop'. check error messages with variables
++------+
+| TEST | (24) test_fail_assert_true_define
+| FAIL | (24)  | test.c:35: assertion failed: 'A > B' - check error messages with preprocessor definitions
++------+
+| TEST | (25) test_fail_assert_true_formatted_message
+| FAIL | (25)  | test.c:15: assertion failed: '0 > 1' - not that useful
++------+
+| TEST | (26) test_fail_assert_true_literal
+| FAIL | (26)  | test.c:20: assertion failed: '0 > 1' - check error messages with literals
++------+
+| TEST | (27) test_fail_assert_true_var
+| FAIL | (27)  | test.c:28: assertion failed: 'a == b' - check error messages with variable names
++------+
+| TEST | (28) test_fail_assert_uint_eq_define
+| FAIL | (28)  | test.c:93: assertion failed: 'A == B'. Values: 5, 10. check error messages with preprocessor definitions
++------+
+| TEST | (29) test_fail_assert_uint_eq_literal
+| FAIL | (29)  | test.c:78: assertion failed: '20 == 10'. Values: 20, 10. check error messages with literals
++------+
+| TEST | (30) test_fail_assert_uint_eq_no_message
+| FAIL | (30)  | test.c:74: assertion failed: '20 == 10'. Values: 20, 10. 
++------+
+| TEST | (31) test_fail_assert_uint_eq_var
+| FAIL | (31)  | test.c:86: assertion failed: 'a == b'. Values: 2, 3. check error messages with variable names
++------+
+| TEST | (32) test_fail_assert_uint_ne_define
+| FAIL | (32)  | test.c:120: assertion failed: 'A != B'. Values: 500, 500. check error messages with preprocessor definitions
++------+
+| TEST | (33) test_fail_assert_uint_ne_literal
+| FAIL | (33)  | test.c:105: assertion failed: '20 != 20'. Values: 20, 20. check error messages with literals
++------+
+| TEST | (34) test_fail_assert_uint_ne_var
+| FAIL | (34)  | test.c:113: assertion failed: 'a != b'. Values: 3, 3. check error messages with variable names
++------+
+| TEST | (35) test_fail_in_setup
+| FAIL | (35)  | test.c:360: assertion failed: '1 == 4' - this should fail
++------+
+| TEST | (36) test_fail_with_custom_func
+| FAIL | (36)  | test.c:405: assertion failed: 'false' - 
++------+
+| TEST | (37) test_fail_with_free
+| FAIL | (37)  | test.c:388: assertion failed: 'false' - 
++------+
+| TEST | (38) test_fail_with_null_handler
+| FAIL | (38)  | test.c:412: assertion failed: 'false' - 
++------+
+| TEST | (39) test_pass_assert_false
+| PASS | (39) 
++------+
+| TEST | (40) test_pass_assert_int_eq
+| PASS | (40) 
++------+
+| TEST | (41) test_pass_assert_int_ne
+| PASS | (41) 
++------+
+| TEST | (42) test_pass_assert_mem_eq
+| PASS | (42) 
++------+
+| TEST | (43) test_pass_assert_mem_ne
+| PASS | (43) 
++------+
+| TEST | (44) test_pass_assert_ptr_eq
+| PASS | (44) 
++------+
+| TEST | (45) test_pass_assert_ptr_eq_null
+| PASS | (45) 
++------+
+| TEST | (46) test_pass_assert_ptr_ne
+| PASS | (46) 
++------+
+| TEST | (47) test_pass_assert_ptr_ne_null
+| PASS | (47) 
++------+
+| TEST | (48) test_pass_assert_str_eq
+| PASS | (48) 
++------+
+| TEST | (49) test_pass_assert_str_ne
+| PASS | (49) 
++------+
+| TEST | (50) test_pass_assert_true
+| PASS | (50) 
++------+
+| TEST | (51) test_pass_assert_uint_eq
+| PASS | (51) 
++------+
+| TEST | (52) test_pass_assert_uint_ne
+| PASS | (52) 
++------+
+| TEST | (53) test_pass_in_setup
+| PASS | (53) 
++------+
+| TEST | (54) test_skip
+| SKIP | (54)  |  testing SKIP
++------+
+| TEST | (55) test_skip_without_reason
+| SKIP | (55)  |  
+'------+-----------------
+       |   Total: 56
+       |  Passed: 15
+       |  Failed: 39
+       | Skipped: 2
+       '-----------------
 
-  Total: 56
- Passed: 15
- Failed: 39
-Skipped: 2

--- a/test/global_setup_success/expected_log.txt
+++ b/test/global_setup_success/expected_log.txt
@@ -1,9 +1,12 @@
 Custom global setup!
-[ TEST ] 0 test_single
-[ PASS ] 0 | 
++------+
+| TEST | (0) test_single
+| PASS | (0) 
+'------+-----------------
+       |   Total: 1
+       |  Passed: 1
+       |  Failed: 0
+       | Skipped: 0
+       '-----------------
 
-  Total: 1
- Passed: 1
- Failed: 0
-Skipped: 0
 Custom global teardown!

--- a/testprefix.c
+++ b/testprefix.c
@@ -308,10 +308,11 @@ static int console_test_begin_cb(int index, const char *name, void *private)
 {
     (void)private;
 
+    printf("+------+\n");
     if (isatty(STDOUT_FILENO)) {
-        printf("[ TEST ] %d " FG_BOLD " %s " TERM_RESET "\n", index, name);
+        printf("| TEST | (%d)" FG_BOLD " %s " TERM_RESET "\n", index, name);
     } else {
-        printf("[ TEST ] %d %s\n", index, name);
+        printf("| TEST | (%d) %s\n", index, name);
     }
     return 0;
 }
@@ -336,7 +337,7 @@ static int console_test_end_cb(int index, const char *name,
         result_string = RED_CONST("FAIL");
     }
 
-    printf("[ %s ] %d | %ld ms", result_string, index,
+    printf("| %s | (%d) %ld ms", result_string, index,
            elapsed_time_ms(&result->begin, &result->end));
 
     if (result->message[0] != '\0') {
@@ -351,10 +352,12 @@ static int console_finish_cb(struct test_reporter *self)
 {
     struct console_private *cp = (struct console_private *)self->private;
 
-    printf("\n%s: %d", BOLD_CONST("  Total"), cp->test_count);
-    printf("\n%s: %d", BOLD_CONST(" Passed"), cp->success_counter);
-    printf("\n%s: %d", BOLD_CONST(" Failed"), cp->failure_counter);
-    printf("\n%s: %d\n", BOLD_CONST("Skipped"), cp->skip_counter);
+    printf("'------+-----------------\n");
+    printf("       | %s: %d\n", BOLD_CONST("  Total"), cp->test_count);
+    printf("       | %s: %d\n", BOLD_CONST(" Passed"), cp->success_counter);
+    printf("       | %s: %d\n", BOLD_CONST(" Failed"), cp->failure_counter);
+    printf("       | %s: %d\n", BOLD_CONST("Skipped"), cp->skip_counter);
+    printf("       '-----------------\n\n");
 
     return 0;
 }


### PR DESCRIPTION
It's hard to identify test boundaries in the test report when there are no colors in it (text file, GH actions output,...). It gets more confusing when the test function writes to stdout.

Change the console reporter to include a clear separation between tests, one that doesn't rely on colors.
Make the test summary more evident, to stand out in a noisy log.