### PR TITLE
Improve error message for memory comparison

### DIFF
--- a/test/assert/expected_log.tap
+++ b/test/assert/expected_log.tap
@@ -87,7 +87,7 @@ not ok 12 test_fail_assert_mem_eq_first_byte
   ---
   message: '
   test.c:307: a1 and a2 were expected to contain the same data
-    First: aabbcc
+     First: aabbcc
     Second: ddbbcc
     first byte different
   '
@@ -96,7 +96,7 @@ not ok 13 test_fail_assert_mem_eq_last_byte
   ---
   message: '
   test.c:315: a1 and a2 were expected to contain the same data
-    First: aabbcc
+     First: aabbcc
     Second: aabbdd
     last byte different
   '
@@ -105,7 +105,7 @@ not ok 14 test_fail_assert_mem_eq_no_message
   ---
   message: '
   test.c:299: a1 and a2 were expected to contain the same data
-    First: aabbcc
+     First: aabbcc
     Second: ddbbcc
   '
   ...
@@ -113,7 +113,7 @@ not ok 15 test_fail_assert_mem_eq_truncated_buf
   ---
   message: '
   test.c:329: a1 and a2 were expected to contain the same data
-    First: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+     First: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
     Second: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1e
     big buffer, last byte different
   '
@@ -122,7 +122,7 @@ not ok 16 test_fail_assert_mem_ne
   ---
   message: '
   test.c:357: a1 and a2 were expected to contain different data
-    First: aabbcc
+     First: aabbcc
     Second: aabbcc
     same content, size: 3
   '

--- a/test/assert/expected_log.txt
+++ b/test/assert/expected_log.txt
@@ -62,34 +62,34 @@
 +------+
 | TEST | (11) test_fail_assert_mem_eq_first_byte
 |      |   test.c:307: a1 and a2 were expected to contain the same data
-|      |     First: aabbcc
+|      |      First: aabbcc
 |      |     Second: ddbbcc
 |      |     first byte different
 | FAIL | (11) 
 +------+
 | TEST | (12) test_fail_assert_mem_eq_last_byte
 |      |   test.c:315: a1 and a2 were expected to contain the same data
-|      |     First: aabbcc
+|      |      First: aabbcc
 |      |     Second: aabbdd
 |      |     last byte different
 | FAIL | (12) 
 +------+
 | TEST | (13) test_fail_assert_mem_eq_no_message
 |      |   test.c:299: a1 and a2 were expected to contain the same data
-|      |     First: aabbcc
+|      |      First: aabbcc
 |      |     Second: ddbbcc
 | FAIL | (13) 
 +------+
 | TEST | (14) test_fail_assert_mem_eq_truncated_buf
 |      |   test.c:329: a1 and a2 were expected to contain the same data
-|      |     First: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+|      |      First: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
 |      |     Second: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1e
 |      |     big buffer, last byte different
 | FAIL | (14) 
 +------+
 | TEST | (15) test_fail_assert_mem_ne
 |      |   test.c:357: a1 and a2 were expected to contain different data
-|      |     First: aabbcc
+|      |      First: aabbcc
 |      |     Second: aabbcc
 |      |     same content, size: 3
 | FAIL | (15) 

--- a/test/expect/expected_log.tap
+++ b/test/expect/expected_log.tap
@@ -27,7 +27,7 @@ not ok 4 test_fail_expect_mem_eq
   ---
   message: '
   test.c:124: a and b were expected to contain the same data
-    First: 010203
+     First: 010203
     Second: 010204
     EXPECT_MEM_EQ alone can fail the test
   '
@@ -36,7 +36,7 @@ not ok 5 test_fail_expect_mem_ne
   ---
   message: '
   test.c:132: a and b were expected to contain different data
-    First: 010203
+     First: 010203
     Second: 010203
     EXPECT_MEM_NE alone can fail the test
   '

--- a/test/expect/expected_log.txt
+++ b/test/expect/expected_log.txt
@@ -18,14 +18,14 @@
 +------+
 | TEST | (3) test_fail_expect_mem_eq
 |      |   test.c:124: a and b were expected to contain the same data
-|      |     First: 010203
+|      |      First: 010203
 |      |     Second: 010204
 |      |     EXPECT_MEM_EQ alone can fail the test
 | FAIL | (3) 
 +------+
 | TEST | (4) test_fail_expect_mem_ne
 |      |   test.c:132: a and b were expected to contain different data
-|      |     First: 010203
+|      |      First: 010203
 |      |     Second: 010203
 |      |     EXPECT_MEM_NE alone can fail the test
 | FAIL | (4) 
@@ -91,10 +91,10 @@
 |      |   test.c:29: "one" and "one" were expected to be different
 |      |     Values: 'one', 'one'
 |      |   test.c:34: a123 and a321 were expected to contain the same data
-|      |     First: 010203
+|      |      First: 010203
 |      |     Second: 030201
 |      |   test.c:35: a123 and b123 were expected to contain different data
-|      |     First: 010203
+|      |      First: 010203
 |      |     Second: 010203
 |      |   test.c:37: false was expected to be TRUE
 |      |     after failed EXPECT macros, ASSERT still works

--- a/testprefix.h
+++ b/testprefix.h
@@ -95,7 +95,7 @@ void TP_mem_to_string(char *str, size_t str_max_size, const void *mem,
             TP_mem_to_string(b_content, sizeof(b_content), BUF_B, SIZE);       \
             TP_context.result.status = TP_TEST_FAILED;                         \
             TP_send_message(0, __FILE__ ":" TP_LINE_STR ": " ERR_MSG);         \
-            TP_send_message(1, "First: %s", a_content);                        \
+            TP_send_message(1, " First: %s", a_content);                       \
             TP_send_message(1, "Second: %s", b_content);                       \
             TP_send_message(1, "" __VA_ARGS__);                                \
             if (ABORT) {                                                       \


### PR DESCRIPTION
This change adds a simple space character to one of the error messages, so the buffers are printed aligned.
This way, it's easier to spot the difference between the buffers.