### PR TITLE
Implement the macro FAIL()

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ of the report.
 SKIP("Skipped for some reason.");
 ```
 
+## Failing tests
+
+To explicitly fail a test, use the macro `FAIL(...)`. The test will be aborted
+immediately and marked as a failure. A string parameter, that will be included in
+the report, can be provided.
+
+```c
+FAIL("no other option, failing the test");
+```
+
 ## Releasing resources on test failures
 
 When an `ASSERT_` macro fails, the test is aborted immediately. To avoid

--- a/test/macro_check/src/fail.c
+++ b/test/macro_check/src/fail.c
@@ -1,0 +1,11 @@
+// Copyright 2021-2024 Rodrigo Dias Correa. See LICENSE.
+
+#include "testprefix.h"
+
+void test_err1_msg0_FAIL_nomessage() { FAIL(); }
+
+void test_err1_msg1_FAIL_message()
+{
+    FAIL("##expected message##");
+    ASSERT_TRUE(false, "##unexpected message##");
+}

--- a/test/macro_check/test.sh
+++ b/test/macro_check/test.sh
@@ -164,7 +164,7 @@ run_individual_tests()
         # exit status.
         debug_echo "checking summary"
         case $macro_type in
-        ASSERT | EXPECT)
+        ASSERT | EXPECT | FAIL)
             if [[ $expected_error_count -eq 0 ]]; then
                 test $test_status = "PASS"
                 test $total_passed -eq 1
@@ -185,6 +185,10 @@ run_individual_tests()
             test $total_passed -eq 0
             test $total_failed -eq 0
             test $test_exit_code -eq 0
+            ;;
+        *)
+            echo "unknown macro type: $macro_type"
+            exit 1
             ;;
         esac
 

--- a/testprefix.h
+++ b/testprefix.h
@@ -317,6 +317,14 @@ void TP_mem_to_string(char *str, size_t str_max_size, const void *mem,
         longjmp(TP_context.env, 1);                                            \
     } while (0)
 
+#define FAIL(...)                                                              \
+    do {                                                                       \
+        TP_context.result.status = TP_TEST_FAILED;                             \
+        TP_send_message(0, __FILE__ ":" TP_LINE_STR ": FAIL() invoked");       \
+        TP_send_message(1, "" __VA_ARGS__);                                    \
+        longjmp(TP_context.env, 1);                                            \
+    } while (0)
+
 #define SET_TEST_FAILURE_HANDLER(HANDLER, HANDLER_ARG)                         \
     do {                                                                       \
         if ((HANDLER) != NULL) {                                               \
@@ -326,6 +334,6 @@ void TP_mem_to_string(char *str, size_t str_max_size, const void *mem,
     } while (0)
 
 //                          .-------------------.
-// -------------------------| End Of Public API |-------------------------------
+// -------------------------| End of Public API |-------------------------------
 //                          '-------------------'
 #endif // TESTPREFIX_H_


### PR DESCRIPTION
In some situations, it makes sense to abort a test explicitly. Create the macro FAIL() to avoid using tricks like:

    ASSERT_TRUE(false, "explicitly failed");