### PR TITLE
Disable buffering for stdout

### DIFF
--- a/test/global_setup_failure/expected_log.txt
+++ b/test/global_setup_failure/expected_log.txt
@@ -1,2 +1,2 @@
-Error. TP_global_setup failed.
 Custom global setup with error!
+Error. TP_global_setup failed.

--- a/test/global_setup_success/expected_log.txt
+++ b/test/global_setup_success/expected_log.txt
@@ -1,3 +1,4 @@
+Custom global setup!
 +------+
 | TEST | (0) test_single
 | PASS | (0) 
@@ -8,5 +9,4 @@
        | Skipped: 0
        '-----------------
 
-Custom global setup!
 Custom global teardown!

--- a/test/verbose/test_verbose.c
+++ b/test/verbose/test_verbose.c
@@ -12,16 +12,16 @@ int TP_global_setup()
 
 void test_pass_verbose()
 {
-    dprintf(STDOUT_FILENO, "1 text written to stdout\n");
-    dprintf(STDERR_FILENO, "2 text written to stderr\n");
+    printf("1 text written to stdout\n");
+    printf("2 text written to stderr\n");
 
     ASSERT_TRUE(true, "this will pass");
 }
 
 void test_fail_verbose()
 {
-    dprintf(STDOUT_FILENO, "3 text written to stdout\n");
-    dprintf(STDERR_FILENO, "4 text written to stderr\n");
+    printf("3 text written to stdout\n");
+    printf("4 text written to stderr\n");
 
     ASSERT_TRUE(false, "this will fail");
 }

--- a/testprefix.c
+++ b/testprefix.c
@@ -909,6 +909,10 @@ __attribute__((weak)) void TP_global_teardown() {}
 
 int main(int argc, char *argv[])
 {
+    // testprefix output is not buffered. Disable stdout buffering to keep the
+    // output of the code under test in sync with testprefix's.
+    setbuf(stdout, NULL);
+
     struct cli_args args;
     int ret = parse_args(argc, argv, &args);
     if (ret < 0 || args.print_usage) {


### PR DESCRIPTION
testprefix standard output has no buffering because it doesn't write to the stdout stream. Instead, it writes directly to a file descriptor using 'dprintf'. Most of the time, the code under test uses stdout (buffered). As a consequence, when the test application is executed in verbose mode (-v), it becomes hard to read this mix of buffered and unbuffered outputs.

Disable buffering for stdout, making both outputs unbuffered. This way, prints from the code under test are not truncated and can be seen as expected.