### PR TITLE
Show values in hex too when UINT macros fail

### DIFF
--- a/testprefix.h
+++ b/testprefix.h
@@ -62,8 +62,14 @@ void TP_mem_to_string(char *str, size_t str_max_size, const void *mem,
         if (!(COND)) {                                                         \
             TP_context.result.status = TP_TEST_FAILED;                         \
             TP_send_message(0, __FILE__ ":" TP_LINE_STR ": " ERR_MSG);         \
-            TP_send_message(1, "Values: " FMT ", " FMT, (TYPE)VAL_A,           \
-                            (TYPE)VAL_B);                                      \
+            if (strcmp(#TYPE, "uint64_t") == 0) {                              \
+                TP_send_message(1, "Values: " FMT " (0x%x), " FMT " (0x%x)",   \
+                                (TYPE)VAL_A, (TYPE)VAL_A, (TYPE)VAL_B,         \
+                                (TYPE)VAL_B);                                  \
+            } else {                                                           \
+                TP_send_message(1, "Values: " FMT ", " FMT, (TYPE)VAL_A,       \
+                                (TYPE)VAL_B);                                  \
+            }                                                                  \
             TP_send_message(1, "" __VA_ARGS__);                                \
             if (ABORT) {                                                       \
                 longjmp(TP_context.env, 1);                                    \


### PR DESCRIPTION
When macros that check unsigned values fail, a decimal representation of the values is included in the report. This is enough when the values represent counters or sizes for example. This is not so good when the values represent are error codes or any other number that makes more sense in hexadecimal.

Change all assertion macros that compare unsigned values to include their hexadecimal representation along with the decimal one.