### PR TITLE
Fix hex value displayed when UINT macros fail

### DIFF
--- a/test/failure_handler/expected_log.tap
+++ b/test/failure_handler/expected_log.tap
@@ -9,7 +9,8 @@ not ok 1 test_fail_with_custom_func
 not ok 2 test_fail_with_free
   ---
   message: '
-  test_failure_handler.c:11: false was expected to be TRUE
+  test_failure_handler.c:11: 1 and 2 were expected to be equal
+    Values: 1 (0x1), 2 (0x2)
   '
   ...
 not ok 3 test_fail_with_null_handler

--- a/test/failure_handler/expected_log.txt
+++ b/test/failure_handler/expected_log.txt
@@ -4,7 +4,8 @@
 | FAIL | (0) 
 +------+
 | TEST | (1) test_fail_with_free
-|      |   test_failure_handler.c:11: false was expected to be TRUE
+|      |   test_failure_handler.c:11: 1 and 2 were expected to be equal
+|      |     Values: 1 (0x1), 2 (0x2)
 | FAIL | (1) 
 +------+
 | TEST | (2) test_fail_with_null_handler

--- a/test/failure_handler/test_failure_handler.c
+++ b/test/failure_handler/test_failure_handler.c
@@ -8,7 +8,7 @@ void test_fail_with_free()
     uint8_t *buf = malloc(10);
 
     SET_TEST_FAILURE_HANDLER(free, buf);
-    ASSERT_TRUE(false);
+    ASSERT_UINT_EQ(1, 2);
 }
 
 void file_closer(void *ptr)

--- a/testprefix.h
+++ b/testprefix.h
@@ -63,7 +63,9 @@ void TP_mem_to_string(char *str, size_t str_max_size, const void *mem,
             TP_context.result.status = TP_TEST_FAILED;                         \
             TP_send_message(0, __FILE__ ":" TP_LINE_STR ": " ERR_MSG);         \
             if (strcmp(#TYPE, "uint64_t") == 0) {                              \
-                TP_send_message(1, "Values: " FMT " (0x%x), " FMT " (0x%x)",   \
+                TP_send_message(1,                                             \
+                                "Values: " FMT " (0x%" PRIx64 "), " FMT        \
+                                " (0x%" PRIx64 ")",                            \
                                 (TYPE)VAL_A, (TYPE)VAL_A, (TYPE)VAL_B,         \
                                 (TYPE)VAL_B);                                  \
             } else {                                                           \


### PR DESCRIPTION
On 32-bit binaries, '%x' is not the right format specifier for uint64_t.

Replace '%x' with PRIx64 macro, which expands to the right format specifier.