### PR TITLE
Make assertion macros safe

### DIFF
--- a/test/macro_check/src/mem_tests.h
+++ b/test/macro_check/src/mem_tests.h
@@ -1,8 +1,9 @@
 // Copyright 2021-2024 Rodrigo Dias Correa. See LICENSE.
 
+#include <assert.h>
 #define MIN(A, B) ((A) < (B) ? (A) : (B))
 
-// Standard set of tests for mactos that check the content of memory buffers,
+// Standard set of tests for macros that check the content of memory buffers,
 // such as ASSERT_MEM_EQ, EXPECT_MEM_EQ, ASSERT_MEM_NE and EXPECT_MEM_NE.
 
 #define BASIC_MEM_MACRO_TEST_SET(MACRO, BUF1, BUF2_SUCCESS, BUF2_FAILURE)      \
@@ -41,6 +42,28 @@
         MACRO(BUF1, BUF2_SUCCESS, size, "##unexpected message##");             \
         MACRO(BUF1, BUF2_SUCCESS, size, "##unexpected message##");             \
         MACRO(BUF1, BUF2_SUCCESS, size, "##unexpected message##");             \
+    }                                                                          \
+    /* The macro works with arguments that have side effects */                \
+    void test_err1_msg1_##MACRO##_side_effect_arguments()                      \
+    {                                                                          \
+        int i = 0, j = 0, k = 0;                                               \
+        size_t size = MIN(sizeof(BUF1), sizeof(BUF2_SUCCESS));                 \
+        MACRO((i++, BUF1), (j++, BUF2_FAILURE), (k++, size),                   \
+              "##expected message##");                                         \
+        assert(i == 1);                                                        \
+        assert(j == 1);                                                        \
+        assert(k == 1);                                                        \
+    }                                                                          \
+    /* The macro works with arguments that have side effects */                \
+    void test_err0_msg0_##MACRO##_side_effect_arguments()                      \
+    {                                                                          \
+        int i = 0, j = 0, k = 0;                                               \
+        size_t size = MIN(sizeof(BUF1), sizeof(BUF2_SUCCESS));                 \
+        MACRO((i++, BUF1), (j++, BUF2_SUCCESS), (k++, size),                   \
+              "##unexpected message##");                                       \
+        assert(i == 1);                                                        \
+        assert(j == 1);                                                        \
+        assert(k == 1);                                                        \
     }
 
 // Set of tests that provide the same buffer (BUF)

--- a/test/macro_check/src/one_param_tests.h
+++ b/test/macro_check/src/one_param_tests.h
@@ -9,6 +9,8 @@
 //             to fail. Ex.: #define ERROR_VALUE false
 //
 
+#include <assert.h>
+
 #define ONE_PARAM_MACRO_TEST_SET(MACRO, PARAM_SUCCESS, PARAM_FAILURE)          \
     /* A successful check does not fail the test */                            \
     void test_err0_msg0_##MACRO##_ok()                                         \
@@ -52,4 +54,18 @@
         MACRO(PARAM_SUCCESS, "##unexpected message##");                        \
         MACRO(PARAM_SUCCESS, "##unexpected message##");                        \
         MACRO(PARAM_SUCCESS, "##unexpected message##");                        \
+    }                                                                          \
+    /* The macro works with arguments that have side effects */                \
+    void test_err1_msg1_##MACRO##_side_effect_arguments()                      \
+    {                                                                          \
+        int i = 0;                                                             \
+        MACRO((i++, PARAM_FAILURE), "##expected message##");                   \
+        assert(i == 1);                                                        \
+    }                                                                          \
+    /* The macro works with arguments that have side effects */                \
+    void test_err0_msg0_##MACRO##_side_effect_arguments()                      \
+    {                                                                          \
+        int i = 0;                                                             \
+        MACRO((i++, PARAM_SUCCESS), "##unexpected message##");                 \
+        assert(i == 1);                                                        \
     }

--- a/test/macro_check/src/two_param_tests.h
+++ b/test/macro_check/src/two_param_tests.h
@@ -9,6 +9,8 @@
 //             to fail. Ex.: #define ERROR_VALUE false
 //
 
+#include <assert.h>
+
 #define TWO_PARAM_MACRO_TEST_SET(MACRO, PARAM1, PARAM2_SUCCESS,                \
                                  PARAM2_FAILURE, VAR_TYPE)                     \
     /* A successful check does not fail the test */                            \
@@ -54,4 +56,22 @@
         MACRO(PARAM1, PARAM2_SUCCESS, "##unexpected message##");               \
         MACRO(PARAM1, PARAM2_SUCCESS, "##unexpected message##");               \
         MACRO(PARAM1, PARAM2_SUCCESS, "##unexpected message##");               \
+    }                                                                          \
+    /* The macro works with arguments that have side effects */                \
+    void test_err1_msg1_##MACRO##_side_effect_arguments()                      \
+    {                                                                          \
+        int i = 0;                                                             \
+        int j = 0;                                                             \
+        MACRO((i++, PARAM1), (j++, PARAM2_FAILURE), "##expected message##");   \
+        assert(i == 1);                                                        \
+        assert(j == 1);                                                        \
+    }                                                                          \
+    /* The macro works with arguments that have side effects */                \
+    void test_err0_msg0_##MACRO##_side_effect_arguments()                      \
+    {                                                                          \
+        int i = 0;                                                             \
+        int j = 0;                                                             \
+        MACRO((i++, PARAM1), (j++, PARAM2_SUCCESS), "##unexpected message##"); \
+        assert(i == 1);                                                        \
+        assert(j == 1);                                                        \
     }

--- a/testprefix.h
+++ b/testprefix.h
@@ -71,27 +71,22 @@ void TP_report_call_traces(unsigned int level);
     } while (0)
 
 #define TP_BASE_COMPARISON(COND, ERR_MSG, ABORT, VAL_A, VAL_B, FMT, TYPE, ...) \
-    do {                                                                       \
-        if (!(COND)) {                                                         \
-            TP_context.result.status = TP_TEST_FAILED;                         \
-            TP_report_call_traces(0);                                          \
-            TP_send_message(0, __FILE__ ":" TP_LINE_STR ": " ERR_MSG);         \
-            if (strcmp(#TYPE, "uint64_t") == 0) {                              \
-                TP_send_message(1,                                             \
-                                "Values: " FMT " (0x%" PRIx64 "), " FMT        \
-                                " (0x%" PRIx64 ")",                            \
-                                (TYPE)VAL_A, (TYPE)VAL_A, (TYPE)VAL_B,         \
-                                (TYPE)VAL_B);                                  \
-            } else {                                                           \
-                TP_send_message(1, "Values: " FMT ", " FMT, (TYPE)VAL_A,       \
-                                (TYPE)VAL_B);                                  \
-            }                                                                  \
-            TP_send_message(1, "" __VA_ARGS__);                                \
-            if (ABORT) {                                                       \
-                longjmp(TP_context.env, 1);                                    \
-            }                                                                  \
+    if (!(COND)) {                                                             \
+        TP_context.result.status = TP_TEST_FAILED;                             \
+        TP_report_call_traces(0);                                              \
+        TP_send_message(0, __FILE__ ":" TP_LINE_STR ": " ERR_MSG);             \
+        if (strcmp(#TYPE, "uint64_t") == 0) {                                  \
+            TP_send_message(                                                   \
+                1, "Values: " FMT " (0x%" PRIx64 "), " FMT " (0x%" PRIx64 ")", \
+                VAL_A, VAL_A, VAL_B, VAL_B);                                   \
+        } else {                                                               \
+            TP_send_message(1, "Values: " FMT ", " FMT, VAL_A, VAL_B);         \
         }                                                                      \
-    } while (0)
+        TP_send_message(1, "" __VA_ARGS__);                                    \
+        if (ABORT) {                                                           \
+            longjmp(TP_context.env, 1);                                        \
+        }                                                                      \
+    }
 
 #define TP_BASE_MEM_COMPARISON(COND, ERR_MSG, ABORT, BUF_A, BUF_B, SIZE, ...)  \
     do {                                                                       \
@@ -135,204 +130,372 @@ void TP_report_call_traces(unsigned int level);
 
 // Unsigned integer comparison
 #define ASSERT_UINT_EQ(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) == (VAL2),                                       \
-                       #VAL1 " and " #VAL2 " were expected to be equal", true, \
-                       VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(TP_val1 == TP_val2,                                 \
+                           #VAL1 " and " #VAL2 " were expected to be equal",   \
+                           true, TP_val1, TP_val2, "%" PRIu64, uint64_t,       \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define EXPECT_UINT_EQ(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) == (VAL2),                                       \
-                       #VAL1 " and " #VAL2 " were expected to be equal",       \
-                       false, VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(TP_val1 == TP_val2,                                 \
+                           #VAL1 " and " #VAL2 " were expected to be equal",   \
+                           false, TP_val1, TP_val2, "%" PRIu64, uint64_t,      \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define ASSERT_UINT_NE(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) != (VAL2),                                       \
-                       #VAL1 " and " #VAL2 " were expected to be different",   \
-                       true, VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 != TP_val2,                                                \
+            #VAL1 " and " #VAL2 " were expected to be different", true,        \
+            TP_val1, TP_val2, "%" PRIu64, uint64_t, __VA_ARGS__);              \
+    } while (0)
 
 #define EXPECT_UINT_NE(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) != (VAL2),                                       \
-                       #VAL1 " and " #VAL2 " were expected to be different",   \
-                       false, VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 != TP_val2,                                                \
+            #VAL1 " and " #VAL2 " were expected to be different", false,       \
+            TP_val1, TP_val2, "%" PRIu64, uint64_t, __VA_ARGS__);              \
+    } while (0)
 
 #define ASSERT_UINT_LT(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) < (VAL2),                                        \
-                       #VAL1 " was expected to be less than " #VAL2, true,     \
-                       VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 < TP_val2, #VAL1 " was expected to be less than " #VAL2,   \
+            true, TP_val1, TP_val2, "%" PRIu64, uint64_t, __VA_ARGS__);        \
+    } while (0)
 
 #define EXPECT_UINT_LT(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) < (VAL2),                                        \
-                       #VAL1 " was expected to be less than " #VAL2, false,    \
-                       VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 < TP_val2, #VAL1 " was expected to be less than " #VAL2,   \
+            false, TP_val1, TP_val2, "%" PRIu64, uint64_t, __VA_ARGS__);       \
+    } while (0)
 
 #define ASSERT_UINT_GT(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) > (VAL2),                                        \
-                       #VAL1 " was expected to be greater than " #VAL2, true,  \
-                       VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(TP_val1 > TP_val2,                                  \
+                           #VAL1 " was expected to be greater than " #VAL2,    \
+                           true, TP_val1, TP_val2, "%" PRIu64, uint64_t,       \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define EXPECT_UINT_GT(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) > (VAL2),                                        \
-                       #VAL1 " was expected to be greater than " #VAL2, false, \
-                       VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(TP_val1 > TP_val2,                                  \
+                           #VAL1 " was expected to be greater than " #VAL2,    \
+                           false, TP_val1, TP_val2, "%" PRIu64, uint64_t,      \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define ASSERT_UINT_LE(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) <= (VAL2),                                       \
-                       #VAL1                                                   \
-                       " was expected to be less than or equal to " #VAL2,     \
-                       true, VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 <= TP_val2,                                                \
+            #VAL1 " was expected to be less than or equal to " #VAL2, true,    \
+            TP_val1, TP_val2, "%" PRIu64, uint64_t, __VA_ARGS__);              \
+    } while (0)
 
 #define EXPECT_UINT_LE(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) <= (VAL2),                                       \
-                       #VAL1                                                   \
-                       " was expected to be less than or equal to " #VAL2,     \
-                       false, VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 <= TP_val2,                                                \
+            #VAL1 " was expected to be less than or equal to " #VAL2, false,   \
+            TP_val1, TP_val2, "%" PRIu64, uint64_t, __VA_ARGS__);              \
+    } while (0)
 
 #define ASSERT_UINT_GE(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) >= (VAL2),                                       \
-                       #VAL1                                                   \
-                       " was expected to be greater than or equal to " #VAL2,  \
-                       true, VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 >= TP_val2,                                                \
+            #VAL1 " was expected to be greater than or equal to " #VAL2, true, \
+            TP_val1, TP_val2, "%" PRIu64, uint64_t, __VA_ARGS__);              \
+    } while (0)
 
 #define EXPECT_UINT_GE(VAL1, VAL2, ...)                                        \
-    TP_BASE_COMPARISON((VAL1) >= (VAL2),                                       \
-                       #VAL1                                                   \
-                       " was expected to be greater than or equal to " #VAL2,  \
-                       false, VAL1, VAL2, "%" PRIu64, uint64_t, __VA_ARGS__)
+    do {                                                                       \
+        uint64_t TP_val1 = (uint64_t)(VAL1);                                   \
+        uint64_t TP_val2 = (uint64_t)(VAL2);                                   \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 >= TP_val2,                                                \
+            #VAL1 " was expected to be greater than or equal to " #VAL2,       \
+            false, TP_val1, TP_val2, "%" PRIu64, uint64_t, __VA_ARGS__);       \
+    } while (0)
 
 // Signed integer comparison
 #define ASSERT_INT_EQ(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) == (VAL2),                                       \
-                       #VAL1 " and " #VAL2 " were expected to be equal", true, \
-                       VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(TP_val1 == TP_val2,                                 \
+                           #VAL1 " and " #VAL2 " were expected to be equal",   \
+                           true, TP_val1, TP_val2, "%" PRIi64, int64_t,        \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define EXPECT_INT_EQ(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) == (VAL2),                                       \
-                       #VAL1 " and " #VAL2 " were expected to be equal",       \
-                       false, VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(TP_val1 == TP_val2,                                 \
+                           #VAL1 " and " #VAL2 " were expected to be equal",   \
+                           false, TP_val1, TP_val2, "%" PRIi64, int64_t,       \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define ASSERT_INT_NE(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) != (VAL2),                                       \
-                       #VAL1 " and " #VAL2 " were expected to be different",   \
-                       true, VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 != TP_val2,                                                \
+            #VAL1 " and " #VAL2 " were expected to be different", true,        \
+            TP_val1, TP_val2, "%" PRIi64, int64_t, __VA_ARGS__);               \
+    } while (0)
 
 #define EXPECT_INT_NE(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) != (VAL2),                                       \
-                       #VAL1 " and " #VAL2 " were expected to be different",   \
-                       false, VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 != TP_val2,                                                \
+            #VAL1 " and " #VAL2 " were expected to be different", false,       \
+            TP_val1, TP_val2, "%" PRIi64, int64_t, __VA_ARGS__);               \
+    } while (0)
 
 #define ASSERT_INT_LT(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) < (VAL2),                                        \
-                       #VAL1 " was expected to be less than " #VAL2, true,     \
-                       VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 < TP_val2, #VAL1 " was expected to be less than " #VAL2,   \
+            true, TP_val1, TP_val2, "%" PRIi64, int64_t, __VA_ARGS__);         \
+    } while (0)
 
 #define EXPECT_INT_LT(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) < (VAL2),                                        \
-                       #VAL1 " was expected to be less than " #VAL2, false,    \
-                       VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 < TP_val2, #VAL1 " was expected to be less than " #VAL2,   \
+            false, TP_val1, TP_val2, "%" PRIi64, int64_t, __VA_ARGS__);        \
+    } while (0)
 
 #define ASSERT_INT_GT(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) > (VAL2),                                        \
-                       #VAL1 " was expected to be greater than " #VAL2, true,  \
-                       VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(TP_val1 > TP_val2,                                  \
+                           #VAL1 " was expected to be greater than " #VAL2,    \
+                           true, TP_val1, TP_val2, "%" PRIi64, int64_t,        \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define EXPECT_INT_GT(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) > (VAL2),                                        \
-                       #VAL1 " was expected to be greater than " #VAL2, false, \
-                       VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(TP_val1 > TP_val2,                                  \
+                           #VAL1 " was expected to be greater than " #VAL2,    \
+                           false, TP_val1, TP_val2, "%" PRIi64, int64_t,       \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define ASSERT_INT_LE(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) <= (VAL2),                                       \
-                       #VAL1                                                   \
-                       " was expected to be less than or equal to " #VAL2,     \
-                       true, VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 <= TP_val2,                                                \
+            #VAL1 " was expected to be less than or equal to " #VAL2, true,    \
+            TP_val1, TP_val2, "%" PRIi64, int64_t, __VA_ARGS__);               \
+    } while (0)
 
 #define EXPECT_INT_LE(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) <= (VAL2),                                       \
-                       #VAL1                                                   \
-                       " was expected to be less than or equal to " #VAL2,     \
-                       false, VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 <= TP_val2,                                                \
+            #VAL1 " was expected to be less than or equal to " #VAL2, false,   \
+            TP_val1, TP_val2, "%" PRIi64, int64_t, __VA_ARGS__);               \
+    } while (0)
 
 #define ASSERT_INT_GE(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) >= (VAL2),                                       \
-                       #VAL1                                                   \
-                       " was expected to be greater than or equal to " #VAL2,  \
-                       true, VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 >= TP_val2,                                                \
+            #VAL1 " was expected to be greater than or equal to " #VAL2, true, \
+            TP_val1, TP_val2, "%" PRIi64, int64_t, __VA_ARGS__);               \
+    } while (0)
 
 #define EXPECT_INT_GE(VAL1, VAL2, ...)                                         \
-    TP_BASE_COMPARISON((VAL1) >= (VAL2),                                       \
-                       #VAL1                                                   \
-                       " was expected to be greater than or equal to " #VAL2,  \
-                       false, VAL1, VAL2, "%" PRIi64, int64_t, __VA_ARGS__)
+    do {                                                                       \
+        int64_t TP_val1 = (int64_t)(VAL1);                                     \
+        int64_t TP_val2 = (int64_t)(VAL2);                                     \
+        TP_BASE_COMPARISON(                                                    \
+            TP_val1 >= TP_val2,                                                \
+            #VAL1 " was expected to be greater than or equal to " #VAL2,       \
+            false, TP_val1, TP_val2, "%" PRIi64, int64_t, __VA_ARGS__);        \
+    } while (0)
 
 // Pointer comparison
 #define ASSERT_PTR_EQ(PTR1, PTR2, ...)                                         \
-    TP_BASE_COMPARISON((PTR1) == (PTR2),                                       \
-                       #PTR1 " and " #PTR2 " were expected to be equal", true, \
-                       PTR1, PTR2, "%p", void *, __VA_ARGS__)
+    do {                                                                       \
+        void *TP_ptr1 = (void *)(PTR1);                                        \
+        void *TP_ptr2 = (void *)(PTR2);                                        \
+        TP_BASE_COMPARISON(TP_ptr1 == TP_ptr2,                                 \
+                           #PTR1 " and " #PTR2 " were expected to be equal",   \
+                           true, TP_ptr1, TP_ptr2, "%p", void *, __VA_ARGS__); \
+    } while (0)
 
 #define EXPECT_PTR_EQ(PTR1, PTR2, ...)                                         \
-    TP_BASE_COMPARISON((PTR1) == (PTR2),                                       \
-                       #PTR1 " and " #PTR2 " were expected to be equal",       \
-                       false, PTR1, PTR2, "%p", void *, __VA_ARGS__)
+    do {                                                                       \
+        void *TP_ptr1 = (void *)(PTR1);                                        \
+        void *TP_ptr2 = (void *)(PTR2);                                        \
+        TP_BASE_COMPARISON(TP_ptr1 == TP_ptr2,                                 \
+                           #PTR1 " and " #PTR2 " were expected to be equal",   \
+                           false, TP_ptr1, TP_ptr2, "%p", void *,              \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define ASSERT_PTR_NE(PTR1, PTR2, ...)                                         \
-    TP_BASE_COMPARISON((PTR1) != (PTR2),                                       \
-                       #PTR1 " and " #PTR2 " were expected to be different",   \
-                       true, PTR1, PTR2, "%p", void *, __VA_ARGS__)
+    do {                                                                       \
+        void *TP_ptr1 = (void *)(PTR1);                                        \
+        void *TP_ptr2 = (void *)(PTR2);                                        \
+        TP_BASE_COMPARISON(TP_ptr1 != TP_ptr2,                                 \
+                           #PTR1 " and " #PTR2                                 \
+                                 " were expected to be different",             \
+                           true, TP_ptr1, TP_ptr2, "%p", void *, __VA_ARGS__); \
+    } while (0)
 
 #define EXPECT_PTR_NE(PTR1, PTR2, ...)                                         \
-    TP_BASE_COMPARISON((PTR1) != (PTR2),                                       \
-                       #PTR1 " and " #PTR2 " were expected to be different",   \
-                       false, PTR1, PTR2, "%p", void *, __VA_ARGS__)
+    do {                                                                       \
+        void *TP_ptr1 = (void *)(PTR1);                                        \
+        void *TP_ptr2 = (void *)(PTR2);                                        \
+        TP_BASE_COMPARISON(                                                    \
+            TP_ptr1 != TP_ptr2,                                                \
+            #PTR1 " and " #PTR2 " were expected to be different", false,       \
+            TP_ptr1, TP_ptr2, "%p", void *, __VA_ARGS__);                      \
+    } while (0)
 
 // String comparison
 #define ASSERT_STR_EQ(STR1, STR2, ...)                                         \
-    TP_BASE_COMPARISON(STR1 != NULL && STR2 != NULL &&                         \
-                           strcmp(STR1, STR2) == 0,                            \
-                       #STR1 " and " #STR2 " were expected to be equal", true, \
-                       STR1, STR2, "'%s'", const char *, __VA_ARGS__)
+    do {                                                                       \
+        const char *TP_str1 = (const char *)STR1;                              \
+        const char *TP_str2 = (const char *)STR2;                              \
+        TP_BASE_COMPARISON(TP_str1 != NULL && TP_str2 != NULL &&               \
+                               strcmp(TP_str1, TP_str2) == 0,                  \
+                           #STR1 " and " #STR2 " were expected to be equal",   \
+                           true, TP_str1, TP_str2, "'%s'", const char *,       \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define EXPECT_STR_EQ(STR1, STR2, ...)                                         \
-    TP_BASE_COMPARISON(STR1 != NULL && STR2 != NULL &&                         \
-                           strcmp(STR1, STR2) == 0,                            \
-                       #STR1 " and " #STR2 " were expected to be equal",       \
-                       false, STR1, STR2, "'%s'", const char *, __VA_ARGS__)
+    do {                                                                       \
+        const char *TP_str1 = (const char *)STR1;                              \
+        const char *TP_str2 = (const char *)STR2;                              \
+        TP_BASE_COMPARISON(TP_str1 != NULL && TP_str2 != NULL &&               \
+                               strcmp(TP_str1, TP_str2) == 0,                  \
+                           #STR1 " and " #STR2 " were expected to be equal",   \
+                           false, TP_str1, TP_str2, "'%s'", const char *,      \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define ASSERT_STR_NE(STR1, STR2, ...)                                         \
-    TP_BASE_COMPARISON(STR1 != NULL && STR2 != NULL &&                         \
-                           strcmp(STR1, STR2) != 0,                            \
-                       #STR1 " and " #STR2 " were expected to be different",   \
-                       true, STR1, STR2, "'%s'", const char *, __VA_ARGS__)
+    do {                                                                       \
+        const char *TP_str1 = (const char *)STR1;                              \
+        const char *TP_str2 = (const char *)STR2;                              \
+        TP_BASE_COMPARISON(TP_str1 != NULL && TP_str2 != NULL &&               \
+                               strcmp(TP_str1, TP_str2) != 0,                  \
+                           #STR1 " and " #STR2 " were expected to be equal",   \
+                           true, TP_str1, TP_str2, "'%s'", const char *,       \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 #define EXPECT_STR_NE(STR1, STR2, ...)                                         \
-    TP_BASE_COMPARISON(STR1 != NULL && STR2 != NULL &&                         \
-                           strcmp(STR1, STR2) != 0,                            \
-                       #STR1 " and " #STR2 " were expected to be different",   \
-                       false, STR1, STR2, "'%s'", const char *, __VA_ARGS__)
+    do {                                                                       \
+        const char *TP_str1 = (const char *)STR1;                              \
+        const char *TP_str2 = (const char *)STR2;                              \
+        TP_BASE_COMPARISON(TP_str1 != NULL && TP_str2 != NULL &&               \
+                               strcmp(TP_str1, TP_str2) != 0,                  \
+                           #STR1 " and " #STR2 " were expected to be equal",   \
+                           false, TP_str1, TP_str2, "'%s'", const char *,      \
+                           __VA_ARGS__);                                       \
+    } while (0)
 
 // Memory region comparison
 #define ASSERT_MEM_EQ(PTR1, PTR2, SIZE, ...)                                   \
-    TP_BASE_MEM_COMPARISON(memcmp(PTR1, PTR2, SIZE) == 0,                      \
-                           #PTR1 " and " #PTR2                                 \
-                                 " were expected to contain the same data",    \
-                           true, PTR1, PTR2, SIZE, __VA_ARGS__)
+    do {                                                                       \
+        void *TP_ptr1 = (void *)(PTR1);                                        \
+        void *TP_ptr2 = (void *)(PTR2);                                        \
+        size_t TP_size = (size_t)SIZE;                                         \
+        TP_BASE_MEM_COMPARISON(                                                \
+            memcmp(TP_ptr1, TP_ptr2, TP_size) == 0,                            \
+            #PTR1 " and " #PTR2 " were expected to contain the same data",     \
+            true, TP_ptr1, TP_ptr2, TP_size, __VA_ARGS__);                     \
+    } while (0)
 
 #define EXPECT_MEM_EQ(PTR1, PTR2, SIZE, ...)                                   \
-    TP_BASE_MEM_COMPARISON(memcmp(PTR1, PTR2, SIZE) == 0,                      \
-                           #PTR1 " and " #PTR2                                 \
-                                 " were expected to contain the same data",    \
-                           false, PTR1, PTR2, SIZE, __VA_ARGS__)
+    do {                                                                       \
+        void *TP_ptr1 = (void *)(PTR1);                                        \
+        void *TP_ptr2 = (void *)(PTR2);                                        \
+        size_t TP_size = (size_t)SIZE;                                         \
+        TP_BASE_MEM_COMPARISON(                                                \
+            memcmp(TP_ptr1, TP_ptr2, TP_size) == 0,                            \
+            #PTR1 " and " #PTR2 " were expected to contain the same data",     \
+            false, TP_ptr1, TP_ptr2, TP_size, __VA_ARGS__);                    \
+    } while (0)
 
 #define ASSERT_MEM_NE(PTR1, PTR2, SIZE, ...)                                   \
-    TP_BASE_MEM_COMPARISON(memcmp(PTR1, PTR2, SIZE) != 0,                      \
-                           #PTR1 " and " #PTR2                                 \
-                                 " were expected to contain different data",   \
-                           true, PTR1, PTR2, SIZE, __VA_ARGS__)
+    do {                                                                       \
+        void *TP_ptr1 = (void *)(PTR1);                                        \
+        void *TP_ptr2 = (void *)(PTR2);                                        \
+        size_t TP_size = (size_t)SIZE;                                         \
+        TP_BASE_MEM_COMPARISON(                                                \
+            memcmp(TP_ptr1, TP_ptr2, TP_size) != 0,                            \
+            #PTR1 " and " #PTR2 " were expected to contain the same data",     \
+            true, TP_ptr1, TP_ptr2, TP_size, __VA_ARGS__);                     \
+    } while (0)
 
 #define EXPECT_MEM_NE(PTR1, PTR2, SIZE, ...)                                   \
-    TP_BASE_MEM_COMPARISON(memcmp(PTR1, PTR2, SIZE) != 0,                      \
-                           #PTR1 " and " #PTR2                                 \
-                                 " were expected to contain different data",   \
-                           false, PTR1, PTR2, SIZE, __VA_ARGS__)
+    do {                                                                       \
+        void *TP_ptr1 = (void *)(PTR1);                                        \
+        void *TP_ptr2 = (void *)(PTR2);                                        \
+        size_t TP_size = (size_t)SIZE;                                         \
+        TP_BASE_MEM_COMPARISON(                                                \
+            memcmp(TP_ptr1, TP_ptr2, TP_size) != 0,                            \
+            #PTR1 " and " #PTR2 " were expected to contain the same data",     \
+            false, TP_ptr1, TP_ptr2, TP_size, __VA_ARGS__);                    \
+    } while (0)
+
 // .--------------.
 // | Other macros |
 // '--------------'


### PR DESCRIPTION
This means that they expand their arguments exactly once. Avoiding multiple expansions is particularly important for arguments that have side effects.

For example: ASSERT_UINT_EQ(0, i++);

If the second parameter is expanded multiple times, 'i' will be incremented multiple times. If the second parameter is never expanded, 'i' will never be incremented.